### PR TITLE
Update announcement script

### DIFF
--- a/.travis/announce.sh
+++ b/.travis/announce.sh
@@ -16,12 +16,12 @@ fi
 
 ENVIRONMENT=$1
 if [ "$ENVIRONMENT" == "prod" ]; then
-TAG=latest
-elif [ "$ENVIRONMENT" == "staging" ]; then
-TAG=staging
+TAG="latest"
+elif [ "$ENVIRONMENT" == "qa" ]; then
+TAG="develop"
 else
    message UNKNOWN ENVIRONMENT
-   echo 'Allowed values for environment are "staging" or "prod"'
+   echo 'Allowed values for environment are ("prod", "qa")'
    exit 1
 fi
 

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -11,7 +11,7 @@ function message() {
 }
 
 ENVIRONMENT=$1
-TAG="lastest"
+TAG="latest"
 
 if [ "$ENVIRONMENT" == "prod" ]; then
   REGION=$PROD_REGION


### PR DESCRIPTION
One more change to the Travis deployment scripts—looks like the "announce release" script needs to be updated to use `qa` instead of `staging`.

- Update release announcement script to use `prod`/`qa`
- Fix typo in `latest` tag