### PR TITLE
Pipeline/update action version

### DIFF
--- a/.github/workflows/test-execute.yml
+++ b/.github/workflows/test-execute.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       -
         name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       -

--- a/.github/workflows/test-execute.yml
+++ b/.github/workflows/test-execute.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3.7
       -
         name: Build execute image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./dockerfiles/execute/Dockerfile


### PR DESCRIPTION
Since node12 is deprecated we need to update the github action that uses it. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

cc @eskp @sanbotto @OleksandrUA @cristidas @zdumitru